### PR TITLE
XTestFakeKeyEvent took replace of atspi_generate_keyboard_event

### DIFF
--- a/README
+++ b/README
@@ -14,9 +14,8 @@ http://www.linuxdeepin.com/download.cn.html
 
 depend for Linux Deepin
 =======================
-sudo apt-get install libopencv-dev libatspi2.0-dev libx11-dev libv4l-dev \
-                     libcurl4-openssl-dev libkdtree++-dev libjsoncpp-dev \
-                     libusb-1.0-0-dev scons 
+sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \
+                     libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons 
 
 build for Linux Deepin
 ======================

--- a/README.md
+++ b/README.md
@@ -1,43 +1,60 @@
-laserkbd
+laserkbd 
 ========
 
-A Low Cost Laser Projection Keyboard designed by RoboPeak
+A Low Cost Laser Projection Keyboard designed by RoboPeak 
 
-Full Source Code Release
+Full Source Code Release 
 
-NOTE: all the source code is licensed under LGPL.
+NOTE: all the source code is licensed under LGPL. 
 No warranty for the sourcecode and the related software.
 
-get Linux Deepin
+get Linux Deepin 
 ================
-http://www.linuxdeepin.com/download.cn.html
+http://www.linuxdeepin.com/download.cn.html 
 
-depend for Linux Deepin
+depend for Linux Deepin 
 =======================
+```
 sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \
                      libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons 
+```
 
-build for Linux Deepin
+build for Linux Deepin 
 ======================
+```
 cd laser_kbd_neo
 scons
+```
 
-debug for Linux Deepin
+debug for Linux Deepin 
 ======================
+```
 gdb ./laser_kbd_neo/laser_kbd 
 r
-bt
-b ./laser_kbd_neo/src/port/linux/powervideocap_linux.cpp:41
+```
 
-video device whether or not support exposure
+```
+bt
+```
+
+```
+b ./laser_kbd_neo/src/port/linux/powervideocap_linux.cpp:41
+```
+
+video device whether or not support exposure 
 ============================================
+```
 sudo apt-get install v4l-utils
 v4l2-ctl -w --all | grep exposure
+```
 
-opencv BUG
-==========
+opencv 2.4.2 BUG 
+================
 BUG: OpenCV Error: Null pointer (NULL guiReceiver (please create a window)) in cvDestroyWindow, file /tmp/buildd/opencv-2.4.2+dfsg/modules/highgui/src/window_QT.cpp, line 489
 
-FIX: apt-get source libopencv-dev
-     vi modules/highgui/src/window_QT.cpp
-     line 489, return;
+```
+apt-get source libopencv-dev
+vi modules/highgui/src/window_QT.cpp
+:489
+return;
+```

--- a/README.md
+++ b/README.md
@@ -8,53 +8,48 @@ Full Source Code Release
 NOTE: all the source code is licensed under LGPL. 
 No warranty for the sourcecode and the related software.
 
-get Linux Deepin 
-================
-http://www.linuxdeepin.com/download.cn.html 
-
-depend for Linux Deepin 
-=======================
+## dependence for ArchLinux 
 ```
-sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \
-                     libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons 
+sudo pacman -Syu
+sudo pacman -S opencv libx11 v4l-utils curl jsoncpp libusbx scons 
 ```
 
-build for Linux Deepin 
-======================
+## build
 ```
 cd laser_kbd_neo
 scons
 ```
+* different keyboard layout
+https://github.com/xiangzhai/laserkbd/issues/2
+```
+vi ./laser_kbd_neo/SConstruct 
+feature_pattern_type_2 = 0
+```
 
-debug for Linux Deepin 
-======================
+## debug 
 ```
 gdb ./laser_kbd_neo/laser_kbd 
 r
 ```
 
+if segfault
 ```
 bt
 ```
 
+set breakpoint, for example:
 ```
 b ./laser_kbd_neo/src/port/linux/powervideocap_linux.cpp:41
 ```
 
-video device whether or not support exposure 
-============================================
+## video device whether or not support exposure 
 ```
-sudo apt-get install v4l-utils
 v4l2-ctl -w --all | grep exposure
 ```
 
-opencv 2.4.2 BUG 
-================
-BUG: OpenCV Error: Null pointer (NULL guiReceiver (please create a window)) in cvDestroyWindow, file /tmp/buildd/opencv-2.4.2+dfsg/modules/highgui/src/window_QT.cpp, line 489
-
-```
-apt-get source libopencv-dev
-vi modules/highgui/src/window_QT.cpp
-:489
-return;
-```
+## keycode                                                                      
+```                                                                             
+sudo pacman -S xorg-xev                                                         
+xev                     
+```                                                        
+hip keyboard too see the keycode                                                             

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ No warranty for the sourcecode and the related software.
 ```
 sudo pacman -Syu
 sudo pacman -S opencv libx11 v4l-utils curl jsoncpp libusbx scons 
+manual install libkdtree++
 ```
 
 ## build

--- a/README.md
+++ b/README.md
@@ -8,11 +8,27 @@ Full Source Code Release
 NOTE: all the source code is licensed under LGPL. 
 No warranty for the sourcecode and the related software.
 
-## dependence for ArchLinux 
+## dependence 
+
+### Ubuntu
+```
+sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \
+                     libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons
+```
+
+### ArchLinux
 ```
 sudo pacman -Syu
 sudo pacman -S opencv libx11 v4l-utils curl jsoncpp libusbx scons 
-manual install libkdtree++
+```
+install libkdtree++
+```
+git clone git://git.debian.org/git/libkdtree/libkdtree.git
+cd libkdtree
+./autogen.sh
+./configure --prefix=/usr
+make
+sudo make install
 ```
 
 ## build

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -12,6 +12,7 @@ RoboPeak设计的低成本激光键盘
 sudo pacman -Syu                                                                
 sudo pacman -S opencv libx11 v4l-utils curl jsoncpp libusbx scons
 ```
+手动安装libkdtree++
 
 ## 编译 
 ```

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -1,0 +1,59 @@
+laserkbd 
+========
+
+RoboPeak设计的低成本激光键盘
+
+公开发布了所有的源代码。 
+
+注：所有的源代码遵循LGPL。
+
+下载Linux Deepin 
+================
+http://www.linuxdeepin.com/download.cn.html 
+
+依赖项 
+======
+```
+sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \
+                     libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons 
+```
+
+编译 
+====
+```
+cd laser_kbd_neo
+scons
+```
+
+调试 
+====
+```
+gdb ./laser_kbd_neo/laser_kbd 
+r
+```
+
+```
+bt
+```
+
+```
+b ./laser_kbd_neo/src/port/linux/powervideocap_linux.cpp:41
+```
+
+视频设备是否支持曝光 
+====================
+```
+sudo apt-get install v4l-utils
+v4l2-ctl -w --all | grep exposure
+```
+
+opencv 2.4.2 BUG 
+================
+BUG: OpenCV Error: Null pointer (NULL guiReceiver (please create a window)) in cvDestroyWindow, file /tmp/buildd/opencv-2.4.2+dfsg/modules/highgui/src/window_QT.cpp, line 489
+
+```
+apt-get source libopencv-dev
+vi modules/highgui/src/window_QT.cpp
+:489
+return;
+```

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -7,53 +7,48 @@ RoboPeak设计的低成本激光键盘
 
 注：所有的源代码遵循LGPL。
 
-下载Linux Deepin 
-================
-http://www.linuxdeepin.com/download.cn.html 
-
-依赖项 
-======
+## 依赖项 
 ```
-sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \
-                     libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons 
+sudo pacman -Syu                                                                
+sudo pacman -S opencv libx11 v4l-utils curl jsoncpp libusbx scons
 ```
 
-编译 
-====
+## 编译 
 ```
 cd laser_kbd_neo
 scons
 ```
+* 不同的键盘布局                                                
+https://github.com/xiangzhai/laserkbd/issues/2                                  
+```                                                                             
+vi ./laser_kbd_neo/SConstruct                                                   
+feature_pattern_type_2 = 0                                                      
+```
 
-调试 
-====
+## 调试 
 ```
 gdb ./laser_kbd_neo/laser_kbd 
 r
 ```
 
+如果遇到段错误
 ```
 bt
 ```
 
+例如设置断点
 ```
 b ./laser_kbd_neo/src/port/linux/powervideocap_linux.cpp:41
 ```
 
-视频设备是否支持曝光 
-====================
+## 视频设备是否支持曝光 
 ```
-sudo apt-get install v4l-utils
 v4l2-ctl -w --all | grep exposure
 ```
 
-opencv 2.4.2 BUG 
-================
-BUG: OpenCV Error: Null pointer (NULL guiReceiver (please create a window)) in cvDestroyWindow, file /tmp/buildd/opencv-2.4.2+dfsg/modules/highgui/src/window_QT.cpp, line 489
-
+## keycode
 ```
-apt-get source libopencv-dev
-vi modules/highgui/src/window_QT.cpp
-:489
-return;
+sudo pacman -S xorg-xev
+xev 
 ```
+敲击键盘查看keycode

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -7,12 +7,28 @@ RoboPeak设计的低成本激光键盘
 
 注：所有的源代码遵循LGPL。
 
-## 依赖项 
+## 依赖
+
+### Ubuntu
+```
+sudo apt-get install libopencv-dev libx11-dev libv4l-dev libcurl4-openssl-dev \ 
+                     libkdtree++-dev libjsoncpp-dev libusb-1.0-0-dev scons
+```
+
+### ArchLinux
 ```
 sudo pacman -Syu                                                                
 sudo pacman -S opencv libx11 v4l-utils curl jsoncpp libusbx scons
 ```
 手动安装libkdtree++
+```                                                                             
+git clone git://git.debian.org/git/libkdtree/libkdtree.git                      
+cd libkdtree                                                                    
+./autogen.sh                                                                    
+./configure --prefix=/usr                                                       
+make                                                                            
+sudo make install                                                               
+```
 
 ## 编译 
 ```

--- a/laser_kbd_neo/SConstruct
+++ b/laser_kbd_neo/SConstruct
@@ -1,7 +1,7 @@
 env = Environment(CCFLAGS='-g')
 env['CPPPATH'] = ['/usr/include/jsoncpp', './src', './src/cvui']
 env['LIBS'] = ['libv4l2', 'libpthread', 'libjsoncpp']
-env.ParseConfig('pkg-config --cflags --libs opencv atspi-2 x11 libusb-1.0 libcurl')
+env.ParseConfig('pkg-config --cflags --libs opencv x11 xtst libusb-1.0 libcurl')
 
 env.Program('laser_kbd', ['./src/main.cpp', 
                           './src/port/linux/powervideocap_linux.cpp',

--- a/laser_kbd_neo/SConstruct
+++ b/laser_kbd_neo/SConstruct
@@ -1,7 +1,37 @@
+debug = 0
+feature_pattern_type_2 = 1
+
+def print_config(msg, two_dee_iterable):
+    # this function is handy and can be used for other configuration-printing tasks
+    print
+    print msg
+    print
+    for key, val in two_dee_iterable:
+        print "    %-20s %s" % (key, val)
+    print
+
+def config_h_build(target, source, env):
+    config_h_defines = {
+        # this is where you put all of your custom configuration values
+        "debug": debug, # this is an int.  1 for true, 0 for false
+        "feature_pattern_type_2": feature_pattern_type_2, 
+    }
+
+    print_config("Generating config.h with the following settings:",
+                  config_h_defines.items())
+
+    for a_target, a_source in zip(target, source):
+        config_h = file(str(a_target), "w")
+        config_h_in = file(str(a_source), "r")
+        config_h.write(config_h_in.read() % config_h_defines)
+        config_h_in.close()
+        config_h.close()
+
 env = Environment(CCFLAGS='-g')
 env['CPPPATH'] = ['/usr/include/jsoncpp', './src', './src/cvui']
 env['LIBS'] = ['libv4l2', 'libpthread', 'libjsoncpp']
 env.ParseConfig('pkg-config --cflags --libs opencv x11 xtst libusb-1.0 libcurl')
+env.AlwaysBuild(env.Command('./src/config.h', './src/config.h.in', config_h_build))
 
 env.Program('laser_kbd', ['./src/main.cpp', 
                           './src/port/linux/powervideocap_linux.cpp',

--- a/laser_kbd_neo/src/config.h.in
+++ b/laser_kbd_neo/src/config.h.in
@@ -1,0 +1,11 @@
+#if %(debug)d
+#define DEBUG 1
+#else
+#define NDEBUG 1
+#endif
+
+#if %(feature_pattern_type_2)d
+#define FEATURE_PATTERN_TYPE_2 1
+#else
+#define NFEATURE_PATTERN_TYPE_2 1
+#endif

--- a/laser_kbd_neo/src/keyboard_emu/layout_provider.cpp
+++ b/laser_kbd_neo/src/keyboard_emu/layout_provider.cpp
@@ -7,6 +7,7 @@
  *  http://www.robopeak.net
  */
 
+#include "../config.h"
 #include "../common.h"
 #include "../cv_common.h"
 #include <algorithm>

--- a/laser_kbd_neo/src/keyboard_emu/layout_provider.cpp
+++ b/laser_kbd_neo/src/keyboard_emu/layout_provider.cpp
@@ -7,7 +7,11 @@
  *  http://www.robopeak.net
  */
 
+#if defined(WIN32) || defined(DARWIN)
+#define FEATURE_PATTERN_TYPE_2
+#else
 #include "../config.h"
+#endif
 #include "../common.h"
 #include "../cv_common.h"
 #include <algorithm>

--- a/laser_kbd_neo/src/keyboard_emu/layout_provider.cpp
+++ b/laser_kbd_neo/src/keyboard_emu/layout_provider.cpp
@@ -16,7 +16,6 @@
 #include "kdtree++/kdtree.hpp"
 
 static const float MAX_KEY_BUTTON_SIZE = 60.0f;
-#define FEATURE_PATTERN_TYPE_2
 
 const static KeyDesc_t _key_mapper[] =
 { 

--- a/laser_kbd_neo/src/port/linux/inc/arch_inc.h
+++ b/laser_kbd_neo/src/port/linux/inc/arch_inc.h
@@ -42,27 +42,28 @@ static inline bool checkPlatformExitFlag()
 #define VK_OEM_MINUS            '-'
 #define VK_ADD                  '+'
 #define VK_OEM_PLUS             '='
-#define VK_ESCAPE               27
-#define VK_BACK                 127
+/* FIXME: what about Linux Virtual Keysym? */
+#define VK_ESCAPE               65307
+#define VK_BACK                 65288
 #define VK_CAPITAL              2 //non-spec
 #define VK_TAB                  '\t'
 #define VK_OEM_1                ';'
-#define VK_RETURN               13
-#define VK_LSHIFT               4 //non-spec
+#define VK_RETURN               65293
+#define VK_LSHIFT               65505 //non-spec
 #define VK_OEM_3                '`'
 #define VK_OEM_5                '\\'
 #define VK_OEM_PERIOD           '.'
 #define VK_OEM_2                '/'
-#define VK_UP                   5 //non-spec
-#define VK_RSHIFT               6 //non-spec
-#define VK_CONTROL              7 //non-spec
-#define VK_MENU                 8    //non-spec , alt
+#define VK_UP                   65362 //non-spec
+#define VK_RSHIFT               65506 //non-spec
+#define VK_CONTROL              65507 //non-spec
+#define VK_MENU                 65383    //non-spec , alt
 #define VK_OEM_4                '['
 #define VK_OEM_6                ']'
 #define VK_SPACE                ' '
-#define VK_DELETE               18 //non-spec
-#define VK_LEFT                 10 //non-spec
-#define VK_DOWN                 11 //non-spec
-#define VK_RIGHT                12 //non-spec
+#define VK_DELETE               65535 //non-spec
+#define VK_LEFT                 65361 //non-spec
+#define VK_DOWN                 65364 //non-spec
+#define VK_RIGHT                65363 //non-spec
 #define VK_OEM_7                '\'' 
 #define VK_OEM_COMMA            ','

--- a/laser_kbd_neo/src/port/linux/inc/arch_inc.h
+++ b/laser_kbd_neo/src/port/linux/inc/arch_inc.h
@@ -42,28 +42,28 @@ static inline bool checkPlatformExitFlag()
 #define VK_OEM_MINUS            '-'
 #define VK_ADD                  '+'
 #define VK_OEM_PLUS             '='
-/* FIXME: what about Linux Virtual Keysym? */
-#define VK_ESCAPE               65307
-#define VK_BACK                 65288
-#define VK_CAPITAL              2 //non-spec
+/* TODO it is based on /usr/share/X11/xkb/keycodes/evdev */
+#define VK_ESCAPE               9
+#define VK_BACK                 22
+#define VK_CAPITAL              66 //non-spec
 #define VK_TAB                  '\t'
 #define VK_OEM_1                ';'
-#define VK_RETURN               65293
-#define VK_LSHIFT               65505 //non-spec
+#define VK_RETURN               36
+#define VK_LSHIFT               50 //non-spec
 #define VK_OEM_3                '`'
 #define VK_OEM_5                '\\'
 #define VK_OEM_PERIOD           '.'
 #define VK_OEM_2                '/'
-#define VK_UP                   65362 //non-spec
-#define VK_RSHIFT               65506 //non-spec
-#define VK_CONTROL              65507 //non-spec
-#define VK_MENU                 65383    //non-spec , alt
+#define VK_UP                   111 //non-spec
+#define VK_RSHIFT               62 //non-spec
+#define VK_CONTROL              37 //non-spec
+#define VK_MENU                 135    //non-spec , alt
 #define VK_OEM_4                '['
 #define VK_OEM_6                ']'
 #define VK_SPACE                ' '
-#define VK_DELETE               65535 //non-spec
-#define VK_LEFT                 65361 //non-spec
-#define VK_DOWN                 65364 //non-spec
-#define VK_RIGHT                65363 //non-spec
+#define VK_DELETE               119 //non-spec
+#define VK_LEFT                 113 //non-spec
+#define VK_DOWN                 116 //non-spec
+#define VK_RIGHT                114 //non-spec
 #define VK_OEM_7                '\'' 
 #define VK_OEM_COMMA            ','

--- a/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
+++ b/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
@@ -62,7 +62,7 @@ public :
         {                                                                   
             keyval = intputlist[pos].keyval;
             keycode = m_KeysymToKeycode(keyval);
-            std::cout << "DEBUG: keyval " << keyval << " keycode " << keycode;
+            std::cout << "DEBUG: keyval " << keyval << " keycode " << keycode << std::endl;
 
             if (intputlist[pos].type == KEY_EVENT_PRESSED) 
             {                

--- a/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
+++ b/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
@@ -23,6 +23,7 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/XTest.h>
 
+#include "config.h"
 #include "common.h"
 #include "port/common/keyinjector.h"
 #include "config_mgr.h"
@@ -62,8 +63,9 @@ public :
         {                                                                   
             keyval = intputlist[pos].keyval;
             keycode = m_KeysymToKeycode(keyval);
+#if DEBUG
             std::cout << "DEBUG: keyval " << keyval << " keycode " << keycode << std::endl;
-
+#endif
             if (intputlist[pos].type == KEY_EVENT_PRESSED) 
             {                
                 hasinputs = true;

--- a/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
+++ b/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
@@ -62,6 +62,7 @@ public :
         {                                                                   
             keyval = intputlist[pos].keyval;
             keycode = m_KeysymToKeycode(keyval);
+            std::cout << "DEBUG: keyval " << keyval << " keycode " << keycode;
 
             if (intputlist[pos].type == KEY_EVENT_PRESSED) 
             {                

--- a/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
+++ b/laser_kbd_neo/src/port/linux/keyinjector_linux.cpp
@@ -20,8 +20,8 @@
  */
 
 #include <iostream>
-#include <atspi/atspi.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/XTest.h>
 
 #include "common.h"
 #include "port/common/keyinjector.h"
@@ -62,15 +62,14 @@ public :
         {                                                                   
             keyval = intputlist[pos].keyval;
             keycode = m_KeysymToKeycode(keyval);
-            //printf("DEBUG: keyval %d keycode %d\n", keyval, keycode);
 
             if (intputlist[pos].type == KEY_EVENT_PRESSED) 
             {                
                 hasinputs = true;
-                atspi_generate_keyboard_event(keycode, NULL, ATSPI_KEY_PRESS, NULL);
+                m_GenKeyEvent(keycode, True);
             } 
             else 
-                atspi_generate_keyboard_event(keycode, NULL, ATSPI_KEY_RELEASE, NULL);         
+                m_GenKeyEvent(keycode, False);         
         }                    
                                                                                 
         if (hasinputs && g_config_bundle.playsound) 
@@ -90,6 +89,14 @@ private:
             return XKeysymToKeycode(m_display, Keysym);
 
         return -1;
+    }
+
+    void m_GenKeyEvent(int Keycode, Bool isPress) 
+    {
+        if (m_display == NULL) 
+            return;
+        XTestFakeKeyEvent(m_display, Keycode, isPress, 0); 
+        XFlush(m_display);
     }
 
 private:

--- a/laser_kbd_neo/test/SConstruct
+++ b/laser_kbd_neo/test/SConstruct
@@ -1,11 +1,13 @@
 env = Environment(CCFLAGS='-g')
 env['CPPPATH'] = ['./../src']
 env['LIBS'] = ['libv4l2', 'libX11']
-env.ParseConfig('pkg-config --cflags --libs atspi-2 libusb-1.0')
+env.ParseConfig('pkg-config --cflags --libs atspi-2 libusb-1.0 x11 xtst')
 
 env.Program('test_productid', ['test_productid.cpp', 
                                './../src/port/linux/productid_linux.cpp'])
 
 env.Program('test_atspi.cpp')
+
+env.Program('test_xtest.cpp')
 
 env.Program('test_v4l2.cpp')

--- a/laser_kbd_neo/test/SConstruct
+++ b/laser_kbd_neo/test/SConstruct
@@ -10,4 +10,6 @@ env.Program('test_atspi.cpp')
 
 env.Program('test_xtest.cpp')
 
+env.Program('test_keycode.cpp')
+
 env.Program('test_v4l2.cpp')

--- a/laser_kbd_neo/test/test_keycode.cpp
+++ b/laser_kbd_neo/test/test_keycode.cpp
@@ -1,0 +1,111 @@
+/*                                                                              
+ * Copyright (C) 2013 Deepin, Inc.                                              
+ *               2013 Leslie Zhai <zhaixiang@linuxdeepin.com> 
+ *                                                                              
+ * This program is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU General Public License as published by         
+ * the Free Software Foundation, either version 3 of the License, or            
+ * any later version.                                                           
+ *                                                                              
+ * This program is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
+ * GNU General Public License for more details.                                 
+ *                                                                              
+ * You should have received a copy of the GNU General Public License            
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.        
+ */
+
+#include <stdio.h>
+#include <X11/Xlib.h>
+
+static Display  *   m_display   = NULL;
+static Visual   *   m_visual    = NULL;
+static Window       m_window;
+static Atom         wmDeleteMessage;
+static bool         m_isLooping = true;
+static int          m_width     = 400;
+static int          m_height    = 300;
+
+static void m_cleanup();
+static void m_loop();
+
+int main(int argc, char* argv[]) {
+    Window rootWin;
+    int screen;
+                                                                                
+    if (!(m_display = XOpenDisplay(NULL))) { 
+        printf("ERROR: fail to XOpenDisplay\n");
+        return 0;
+    }
+
+    screen = DefaultScreen(m_display);                                                     
+    rootWin = RootWindow(m_display, screen);                                               
+    
+    // The actual window, front buffer, using Xdbe enabled Visual
+    unsigned long xAttrMask = CWBackPixel;
+    XSetWindowAttributes xAttr;
+    xAttr.background_pixel = BlackPixel(m_display, screen);
+    m_window = XCreateWindow(m_display, rootWin, 0, 0, m_width, m_height, 0, 
+                             CopyFromParent, CopyFromParent, m_visual, 
+                             xAttrMask, &xAttr);
+    if (!m_window) {
+        printf("ERROR: fail to XCreateWindow\n");
+        return 0;
+    }
+
+    XStoreName(m_display, m_window, "TestKeyCode");
+    XSelectInput(m_display, 
+                 m_window, 
+                 ExposureMask | KeyPressMask | StructureNotifyMask);
+    XMapWindow(m_display, m_window);
+
+    wmDeleteMessage = XInternAtom(m_display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(m_display, m_window, &wmDeleteMessage, 1);
+
+    m_loop();
+
+    m_cleanup();
+
+    return 0;
+}
+
+static void m_cleanup() 
+{
+    if (m_display) {
+        XDestroyWindow(m_display, m_window);
+        XCloseDisplay(m_display);
+        m_display = NULL;
+    }
+}
+
+static void m_loop() 
+{
+    XEvent e;
+
+    m_isLooping = true;
+    while (m_isLooping) {
+		XNextEvent(m_display, &e);
+        switch (e.type) {
+        case Expose:
+            break;
+        case ClientMessage: 
+            if (e.xclient.data.l[0] == wmDeleteMessage) {
+                m_isLooping = false;
+                break;
+            }
+            break;
+        case KeyPress:
+            XKeyEvent xkey = e.xkey;
+            printf("DEBUG: 0x%04x %u -> %u\n", 
+                   XKeycodeToKeysym(m_display, xkey.keycode, 0), 
+                   XKeycodeToKeysym(m_display, xkey.keycode, 0), 
+                   xkey.keycode);
+            switch (XKeycodeToKeysym(m_display, xkey.keycode, 0)) {
+            case 'q':
+                m_isLooping = false;
+                break;
+            }
+        }
+	}
+}

--- a/laser_kbd_neo/test/test_xtest.cpp
+++ b/laser_kbd_neo/test/test_xtest.cpp
@@ -1,0 +1,46 @@
+/*                                                                              
+ * Copyright (C) 2013 Deepin, Inc.                                                 
+ *               2013 Leslie Zhai                                                  
+ *                                                                              
+ * Author:     Leslie Zhai <zhaixiang@linuxdeepin.com>                           
+ * Maintainer: Leslie Zhai <zhaixiang@linuxdeepin.com>                           
+ *                                                                              
+ * This program is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU General Public License as published by         
+ * the Free Software Foundation, either version 3 of the License, or            
+ * any later version.                                                           
+ *                                                                              
+ * This program is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
+ * GNU General Public License for more details.                                 
+ *                                                                              
+ * You should have received a copy of the GNU General Public License            
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.        
+ */
+
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+#include <X11/extensions/XTest.h>
+
+void click_key(Display* display , KeyCode keycode) 
+{
+    XTestFakeKeyEvent(display, keycode, True, 0); // key press event
+    XTestFakeKeyEvent(display, keycode, False, 0); // key release event
+    XFlush(display);
+
+    return;
+}
+
+int main(int argc, char* argv[]) 
+{
+    Display* display = XOpenDisplay(NULL);
+
+    click_key(display, 56);
+
+    XCloseDisplay(display);
+    display = NULL;
+
+    return 0;
+}

--- a/laser_kbd_neo/test/test_xtest.cpp
+++ b/laser_kbd_neo/test/test_xtest.cpp
@@ -38,6 +38,7 @@ int main(int argc, char* argv[])
 {
     Display* display = XOpenDisplay(NULL);
 
+    printf("DEBUG: %d\n", XKeysymToKeycode(display, 10));
     // xmodmap -pke
     click_key(display, 56);
 

--- a/laser_kbd_neo/test/test_xtest.cpp
+++ b/laser_kbd_neo/test/test_xtest.cpp
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.        
  */
 
+#include <stdio.h>
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
@@ -37,6 +38,7 @@ int main(int argc, char* argv[])
 {
     Display* display = XOpenDisplay(NULL);
 
+    // xmodmap -pke
     click_key(display, 56);
 
     XCloseDisplay(display);


### PR DESCRIPTION
XTestFakeKeyEvent is X11`s extension, but atspi_generate_keyboard_event is dependent on glib, then KDE or other non-Gnome user might fail to build owing to lack of libatspi.

So I chose more common XTestFakeKeyEvent to take place of atspi_generate_keyboard_event.
